### PR TITLE
Update continuous benchmarking with Bencher

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: '18 * * * *'
+    - cron: '18 0 * * *'
   push:
     branches:
       - main
@@ -20,6 +20,7 @@ jobs:
         run: |
           bencher run \
           --iter 16 \
+          --fold min \
           --branch "$GITHUB_REF_NAME" \
           --token "${{ secrets.BENCHER_API_TOKEN }}" \
           --err \

--- a/.github/workflows/bencher_pr.yml
+++ b/.github/workflows/bencher_pr.yml
@@ -1,11 +1,10 @@
 on: pull_request
 
-permissions:
-  issues: write
-
 jobs:
   benchmark_pr_with_bencher:
-    permissions: write-all
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      pull-requests: write
     name: Continuous Benchmarking with Bencher
     runs-on: ubuntu-latest
     env:
@@ -21,6 +20,7 @@ jobs:
         run: |
           bencher run \
           --iter 2 \
+          --fold min \
           --if-branch "$GITHUB_REF_NAME" \
           --else-if-branch "$GITHUB_BASE_REF" \
           --else-if-branch main \


### PR DESCRIPTION
The cron schedule for the main branch been updated to once a day instead of once every hour.
The benchmark results are still run 16 times.
However, only the minimum result is stored using --fold.
https://bencher.dev/docs/explanation/bencher-run/#--fold-fold
Since every stored result gets compared against its Threshold, making this change will help reduce the number of false positives.

The permissions for the GitHub Token in pull requests has been limited in scope only to write on pull requests.
The job itself has also been limited to only run on internal PRs. This is to prevent pwn requests.
To handle PRs from forks, I can implement either of these in a follow up PR:
https://bencher.dev/docs/how-to/github-actions/#pull-requests-from-forks
The benchmark results are still run 2 times.
However, only the minimum result is stored using --fold, just as we did with the main branch.